### PR TITLE
Braintree error: braintree:merchantId is missing resolved

### DIFF
--- a/android/src/main/java/com/busfor/PaymentsUtil.java
+++ b/android/src/main/java/com/busfor/PaymentsUtil.java
@@ -75,6 +75,18 @@ public class PaymentsUtil {
           if (tokenizationSpecification.hasKey("gatewayMerchantId")) {
             put("gatewayMerchantId", tokenizationSpecification.getString("gatewayMerchantId"));
           }
+          if (tokenizationSpecification.hasKey("braintree:merchantId")) {
+            put("braintree:merchantId", tokenizationSpecification.getString("braintree:merchantId"));
+          }
+          if (tokenizationSpecification.hasKey("braintree:sdkVersion")) {
+            put("braintree:sdkVersion", tokenizationSpecification.getString("braintree:sdkVersion"));
+          }
+          if (tokenizationSpecification.hasKey("braintree:apiVersion")) {
+            put("braintree:apiVersion", tokenizationSpecification.getString("braintree:apiVersion"));
+          }
+          if (tokenizationSpecification.hasKey("braintree:clientKey")) {
+            put("braintree:clientKey", tokenizationSpecification.getString("braintree:clientKey"));
+          }
           if (tokenizationSpecification.hasKey("publicKey")) {
             put("protocolVersion", "ECv2");
             put("publicKey", tokenizationSpecification.getString("publicKey"));


### PR DESCRIPTION
### What was not working
 -> When I implemented braintree i was providing all the fields from react native like this


`tokenizationSpecification: {
      type: 'PAYMENT_GATEWAY',
      gateway: 'braintree',
      'braintree:apiVersion': 'v1',
      'braintree:sdkVersion': 'braintree.client.VERSION',
      'braintree:merchantId': 'string',
      'braintree:clientKey': 'string',
    }`

But when I did `adb -e logcat -s WalletMerchantError`

it showed me `Error in loadPaymentData: braintree:merchantId is missing`


### What I changed 

I added some lines in `getTokenizationSpecification function to add braintree fields when making payment data object`. 


